### PR TITLE
Switch the exported build type to cmake.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -48,6 +48,6 @@
   <depend>suitesparse</depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
Since the ceres-solver build doesn't ever call ament_package(),
the appropriate build files do not get generated with a build
export type of ament_cmake. This only shows up when doing
isolated builds. To fix this, switch the exported build type
to plain cmake, which does generate the appropriate build files.

Change-Id: I3b69bb45a6905d045b69a2a636d7b41f44fe9b80
Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>